### PR TITLE
Set placeholder attribute as optional

### DIFF
--- a/lib/panda_doc/objects/field.rb
+++ b/lib/panda_doc/objects/field.rb
@@ -6,7 +6,7 @@ module PandaDoc
       attribute :uuid, Types::Coercible::String
       attribute :name, Types::Coercible::String.optional
       attribute :title, Types::Coercible::String.optional
-      attribute :placeholder, Types::Coercible::String.optional
+      attribute? :placeholder, Types::Coercible::String.optional
       attribute :value, Types::Nil | Types::Hash | Types::Coercible::String
       attribute? :assigned_to, PandaDoc::Objects::Recipient
     end


### PR DESCRIPTION
`/details` endpoint does not always send a key for `:placeholder`