### PR TITLE
Add `Document.move_to_draft` + `Document.update`

### DIFF
--- a/lib/panda_doc.rb
+++ b/lib/panda_doc.rb
@@ -21,6 +21,7 @@ require "panda_doc/objects/recipient"
 require "panda_doc/objects/token"
 require "panda_doc/objects/field"
 require "panda_doc/objects/document"
+require "panda_doc/objects/empty"
 require "panda_doc/objects/error"
 require "panda_doc/objects/session"
 

--- a/lib/panda_doc/api_client.rb
+++ b/lib/panda_doc/api_client.rb
@@ -51,6 +51,10 @@ module PandaDoc
       connection.get(normalized_path(path), **data)
     end
 
+    def patch(path, data = {})
+      connection.patch(normalized_path(path), **data)
+    end
+
     private
 
     def normalized_path(path)

--- a/lib/panda_doc/document.rb
+++ b/lib/panda_doc/document.rb
@@ -9,7 +9,10 @@ module PandaDoc
     end
 
     def update(uuid, **data)
-      respond(ApiClient.request(:patch, "/documents/#{uuid}", **data))
+      respond(
+        ApiClient.request(:patch, "/documents/#{uuid}", **data),
+        type: :base
+      )
     end
 
     def send(uuid, **data)

--- a/lib/panda_doc/document.rb
+++ b/lib/panda_doc/document.rb
@@ -11,7 +11,7 @@ module PandaDoc
     def update(uuid, **data)
       respond(
         ApiClient.request(:patch, "/documents/#{uuid}", **data),
-        type: :base
+        type: :empty
       )
     end
 

--- a/lib/panda_doc/document.rb
+++ b/lib/panda_doc/document.rb
@@ -8,6 +8,10 @@ module PandaDoc
       respond(ApiClient.request(:post, "/documents", **data))
     end
 
+    def update(uuid, **data)
+      respond(ApiClient.request(:patch, "/documents/#{uuid}", **data))
+    end
+
     def send(uuid, **data)
       respond(ApiClient.request(:post, "/documents/#{uuid}/send", **data))
     end
@@ -18,6 +22,10 @@ module PandaDoc
 
     def details(uuid)
       respond(ApiClient.request(:get, "/documents/#{uuid}/details"))
+    end
+
+    def move_to_draft(uuid)
+      respond(ApiClient.request(:post, "/documents/#{uuid}/draft"))
     end
 
     def session(uuid, **data)

--- a/lib/panda_doc/objects/document.rb
+++ b/lib/panda_doc/objects/document.rb
@@ -15,6 +15,7 @@ module PandaDoc
 
       attribute? :tokens, Types::Array.of(Objects::Token)
       attribute? :fields, Types::Array.of(Objects::Field)
+      attribute? :metadata, Types::Hash
 
       alias_method :created_at, :date_created
       alias_method :updated_at, :date_modified

--- a/lib/panda_doc/objects/empty.rb
+++ b/lib/panda_doc/objects/empty.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module PandaDoc
+  module Objects
+    class Empty
+      def initialize(_response_body)
+      end
+    end
+  end
+end

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -286,4 +286,50 @@ RSpec.describe PandaDoc::Document do
       it_behaves_like "a document object interface"
     end
   end
+
+  describe ".move_to_draft" do
+    subject { described_class.move_to_draft("uuid") }
+
+    before do
+      allow(PandaDoc::ApiClient).to receive(:request)
+        .with(:post, "/documents/uuid/draft")
+        .and_return(response)
+    end
+
+    context "with failed response" do
+      let(:response) { failed_response }
+
+      it_behaves_like "a failure result"
+    end
+
+    context "with successful response" do
+      let(:response) { successful_response }
+      let(:body) { document_body }
+
+      it_behaves_like "a document object interface"
+    end
+  end
+
+  describe ".update" do
+    subject { described_class.update("uuid", metadata: { hello: "world" })}
+
+    before do
+      allow(PandaDoc::ApiClient).to receive(:request)
+        .with(:patch, "/documents/uuid", metadata: { hello: "world" })
+        .and_return(response)
+    end
+
+    context "with failed response" do
+      let(:response) { failed_response }
+
+      it_behaves_like "a failure result"
+    end
+
+    context "with successful response" do
+      let(:response) { successful_response }
+      let(:body) { document_body }
+
+      it_behaves_like "a document object interface"
+    end
+  end
 end

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -327,9 +327,9 @@ RSpec.describe PandaDoc::Document do
 
     context "with successful response" do
       let(:response) { successful_response }
-      let(:body) { document_body }
+      let(:body) { "" }
 
-      it_behaves_like "a document object interface"
+      it { expect { subject }.not_to raise_error }
     end
   end
 end


### PR DESCRIPTION
This updates the Document API to add the following:

- Optional `metadata` [field which can be used to store arbitrary data](https://developers.pandadoc.com/reference/document-details)
- `Document.move_to_draft` -> [`POST /documents/{id}/draft/`](https://developers.pandadoc.com/reference/draft)
- `Document.update` -> [`PATCH /documents/{id}/`](https://developers.pandadoc.com/reference/update-document)