### PR TITLE
feat: Add Document Sections support

### DIFF
--- a/lib/panda_doc/document_section.rb
+++ b/lib/panda_doc/document_section.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module PandaDoc
+  module DocumentSection
+    extend self
+
+    def create(document_uuid, **data)
+      respond(
+        ApiClient.request(:post, "/documents/#{document_uuid}/sections/uploads", **data),
+        type: :document_section
+      )
+    end
+
+    private
+
+    def respond(response, type: :document)
+      failure(response)
+
+      SuccessResult.new(
+        ResponseFactory.build(type).new(response.body)
+      )
+    end
+
+    def stream(response)
+      failure(response)
+
+      SuccessResult.new(response)
+    end
+
+    def failure(response)
+      raise FailureResult.new(response) unless response.success?
+    end
+  end
+end

--- a/lib/panda_doc/objects/document_section.rb
+++ b/lib/panda_doc/objects/document_section.rb
@@ -1,0 +1,16 @@
+module PandaDoc
+  module Objects
+    class DocumentSection < Base
+      attribute :uuid, Types::String
+      attribute :document_uuid, Types::String
+      attribute :status, Types::Custom::DocumentStatus
+      attribute :name, Types::String
+
+      attribute :date_created, Types::Params::DateTime
+      attribute :date_modified, Types::Params::DateTime
+
+      alias_method :created_at, :date_created
+      alias_method :updated_at, :date_modified
+    end
+  end
+end

--- a/spec/document_section_spec.rb
+++ b/spec/document_section_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "helper"
+
+RSpec.shared_examples "a document section object interface" do
+  %w(
+    uuid
+    document_uuid
+    name
+  ).each do |method|
+    it "has #{method}" do
+      expect(subject.public_send(method)).to eq(body[method])
+    end
+  end
+
+  it "has coerced status" do
+    expect(subject.status).to eq("UPLOADED")
+  end
+
+  it "has created_at" do
+    expect(
+      to_seconds(subject.created_at)
+    ).to eq(to_seconds(body["date_created"]))
+  end
+
+  it "has updated_at" do
+    expect(
+      to_seconds(subject.updated_at)
+    ).to eq(to_seconds(body["date_modified"]))
+  end
+end
+
+RSpec.shared_examples "a document section failure result" do
+  it { expect { subject }.to raise_error(PandaDoc::FailureResult) }
+end
+
+
+RSpec.describe PandaDoc::DocumentSection do
+  let(:failed_response) { double(success?: false, body: Hash.new) }
+  let(:successful_response) { double(success?: true, body: body) }
+  let(:document_uuid) { "DOCUMENT_UUID" }
+  let(:document_body) do
+    {
+      "uuid" => "SECTION_UUID",
+      "document_uuid" => "DOCUMENT_UUID",
+      "status" => "document_sections_upload.UPLOADED",
+      "name" => "null",
+      "date_created" => "2023-08-28T15:48:09.379860Z",
+      "date_modified" => "2023-08-28T15:48:09.379860Z",
+      "info_message" => "You need to poll the Document Sections Upload Status method until the status will be changed to document_sections_upload.PROCESSED"
+    }
+  end
+
+  describe ".create" do
+    subject { described_class.create(document_uuid, name: "Foo") }
+
+    before do
+      allow(PandaDoc::ApiClient).to receive(:request)
+        .with(:post, "/documents/#{document_uuid}/sections/uploads", name: "Foo")
+        .and_return(response)
+    end
+
+    context "with failed response" do
+      let(:response) { failed_response }
+
+      it_behaves_like "a document section failure result"
+    end
+
+    context "with successful response" do
+      let(:response) { successful_response }
+      let(:body) { document_body }
+
+      it_behaves_like "a document section object interface"
+    end
+  end
+end


### PR DESCRIPTION
This adds API support for creating document sections: https://developers.pandadoc.com/reference/create-document-section

> Example:

With a previously created `document_uuid`, you can add additional files/sections through:

```ruby
  PandaDoc::DocumentSection.create(
    document_uuid,
    name: "Example Section",
    file:,
  )
```